### PR TITLE
Contracts update

### DIFF
--- a/abis/LimitOrderProtocol.json
+++ b/abis/LimitOrderProtocol.json
@@ -162,45 +162,6 @@
     "type": "event"
   },
   {
-    "inputs": [],
-    "name": "DOMAIN_SEPARATOR",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "LIMIT_ORDER_TYPEHASH",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "MARKET_ORDER_TYPEHASH",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
         "internalType": "uint8",
@@ -281,16 +242,6 @@
               {
                 "internalType": "bytes",
                 "name": "predicate",
-                "type": "bytes"
-              },
-              {
-                "internalType": "bytes",
-                "name": "permit",
-                "type": "bytes"
-              },
-              {
-                "internalType": "bytes",
-                "name": "interaction",
                 "type": "bytes"
               },
               {
@@ -395,16 +346,6 @@
             "type": "bytes"
           },
           {
-            "internalType": "bytes",
-            "name": "permit",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "interaction",
-            "type": "bytes"
-          },
-          {
             "internalType": "address",
             "name": "signer",
             "type": "address"
@@ -470,16 +411,6 @@
             "type": "bytes"
           },
           {
-            "internalType": "bytes",
-            "name": "permit",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "interaction",
-            "type": "bytes"
-          },
-          {
             "internalType": "address",
             "name": "signer",
             "type": "address"
@@ -501,6 +432,19 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "domainSeparator",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
       }
     ],
     "stateMutability": "view",
@@ -577,16 +521,6 @@
           {
             "internalType": "bytes",
             "name": "predicate",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "permit",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "interaction",
             "type": "bytes"
           },
           {
@@ -686,16 +620,6 @@
             "type": "bytes"
           },
           {
-            "internalType": "bytes",
-            "name": "permit",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "interaction",
-            "type": "bytes"
-          },
-          {
             "internalType": "address",
             "name": "signer",
             "type": "address"
@@ -732,127 +656,11 @@
       },
       {
         "internalType": "address",
-        "name": "target",
+        "name": "to",
         "type": "address"
       }
     ],
     "name": "fillOrderTo",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "salt",
-            "type": "uint256"
-          },
-          {
-            "internalType": "address",
-            "name": "makerAsset",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "takerAsset",
-            "type": "address"
-          },
-          {
-            "internalType": "bytes",
-            "name": "makerAssetData",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "takerAssetData",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "getMakerAmount",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "getTakerAmount",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "predicate",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "permit",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "interaction",
-            "type": "bytes"
-          },
-          {
-            "internalType": "address",
-            "name": "signer",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "sigType",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct Orders.LimitOrder",
-        "name": "order",
-        "type": "tuple"
-      },
-      {
-        "internalType": "bytes",
-        "name": "signature",
-        "type": "bytes"
-      },
-      {
-        "internalType": "uint256",
-        "name": "makingAmount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "takingAmount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "thresholdAmount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "target",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes",
-        "name": "permit",
-        "type": "bytes"
-      }
-    ],
-    "name": "fillOrderToWithPermit",
     "outputs": [
       {
         "internalType": "uint256",
@@ -1088,87 +896,6 @@
           },
           {
             "internalType": "address",
-            "name": "makerAsset",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "takerAsset",
-            "type": "address"
-          },
-          {
-            "internalType": "bytes",
-            "name": "makerAssetData",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "takerAssetData",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "getMakerAmount",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "getTakerAmount",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "predicate",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "permit",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "interaction",
-            "type": "bytes"
-          },
-          {
-            "internalType": "address",
-            "name": "signer",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "sigType",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct Orders.LimitOrder",
-        "name": "order",
-        "type": "tuple"
-      }
-    ],
-    "name": "hash",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "salt",
-            "type": "uint256"
-          },
-          {
-            "internalType": "address",
             "name": "signer",
             "type": "address"
           },
@@ -1209,6 +936,77 @@
           }
         ],
         "internalType": "struct Orders.MarketOrder",
+        "name": "order",
+        "type": "tuple"
+      }
+    ],
+    "name": "hash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "makerAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "takerAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "makerAssetData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "takerAssetData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "getMakerAmount",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "getTakerAmount",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "predicate",
+            "type": "bytes"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "sigType",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Orders.LimitOrder",
         "name": "order",
         "type": "tuple"
       }
@@ -1472,24 +1270,6 @@
   {
     "inputs": [
       {
-        "internalType": "address[]",
-        "name": "targets",
-        "type": "address[]"
-      },
-      {
-        "internalType": "bytes[]",
-        "name": "data",
-        "type": "bytes[]"
-      }
-    ],
-    "name": "simulateCalls",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "uint256",
         "name": "time",
         "type": "uint256"
@@ -1561,16 +1341,6 @@
           {
             "internalType": "bytes",
             "name": "predicate",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "permit",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bytes",
-            "name": "interaction",
             "type": "bytes"
           },
           {

--- a/abis/OrderExecutorV2.json
+++ b/abis/OrderExecutorV2.json
@@ -24,13 +24,13 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "from",
         "type": "address"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "to",
         "type": "address"
@@ -43,13 +43,13 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "from",
         "type": "address"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "to",
         "type": "address"
@@ -62,19 +62,19 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "to",
         "type": "address"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "asset",
         "type": "address"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "uint256",
         "name": "id",
         "type": "uint256"
@@ -93,25 +93,69 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "to",
         "type": "address"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "asset",
         "type": "address"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
       }
     ],
     "name": "ERC20AssetWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldFeeCollector",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newFeeCollector",
+        "type": "address"
+      }
+    ],
+    "name": "FeeCollectorChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "feeCollector",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "feeToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "fees",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeesSwept",
     "type": "event"
   },
   {
@@ -157,6 +201,12 @@
         "indexed": false,
         "internalType": "uint256",
         "name": "takerAmountFilled",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fee",
         "type": "uint256"
       }
     ],
@@ -209,19 +259,13 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "name": "executedMarketOrders",
+    "inputs": [],
+    "name": "feeCollector",
     "outputs": [
       {
-        "internalType": "bool",
+        "internalType": "address",
         "name": "",
-        "type": "bool"
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -287,6 +331,16 @@
             "internalType": "bytes",
             "name": "signature",
             "type": "bytes"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fee",
+            "type": "uint256"
           }
         ],
         "internalType": "struct Orders.MarketOrderFillData",
@@ -338,16 +392,6 @@
                 "type": "bytes"
               },
               {
-                "internalType": "bytes",
-                "name": "permit",
-                "type": "bytes"
-              },
-              {
-                "internalType": "bytes",
-                "name": "interaction",
-                "type": "bytes"
-              },
-              {
                 "internalType": "address",
                 "name": "signer",
                 "type": "address"
@@ -394,11 +438,77 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "makerAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerAssetID",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "takerAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerAssetID",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "sigType",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Orders.MarketOrder",
+        "name": "order",
+        "type": "tuple"
+      }
+    ],
+    "name": "hashMarketOrder",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "limitOrderProtocolContract",
     "outputs": [
       {
-        "internalType": "contract ILimitOrderProtocol",
+        "internalType": "contract IPolyLimitOrderProtocol",
         "name": "",
         "type": "address"
       }
@@ -498,6 +608,25 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "remaining",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "renounceOwnership",
     "outputs": [],
@@ -526,6 +655,19 @@
       }
     ],
     "name": "setConditionalToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newFeeCollector",
+        "type": "address"
+      }
+    ],
+    "name": "setFeeCollector",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/networks.yaml
+++ b/networks.yaml
@@ -47,11 +47,11 @@ mumbai:
       transactionHash: '0x994ccfecb4d13de47ff3775c9b63752e4c78ad8f66ea9cc272a3f623b9f10ec1'
       startBlock: 3456423
     LimitOrderProtocol:
-      address: '0x3AA27F87CA17822f305A9788e7b9f5ea43A531FF'
-      transactionHash: '0xebf71d0ded8bb86e2db686cc0f86f4076f6c75a74311f0f6a59caa6fa30a32db'
-      startBlock: 25623241
+      address: '0x6D486b31b5c0f724828Aff07c88606b213B0D196'
+      transactionHash: '0x3eca43c3cadce22bf48e390653df9d8dcb3aaa7c41c7eb3dec14cbf851488f26'
+      startBlock: 26449261
     OrderExecutorV2:
-      address: '0x1199443D6806dE23a9C976193F07A381542F81df'
-      transactionHash: '0x15581b07ac5895ab3561fe59b20eabef6c85ba3d39518f14550c1e4e7f42362f'
-      startBlock: 25623244
+      address: '0x6b0ab7A1E65ea6AE9072f6c45B4261ACDfB30827'
+      transactionHash: '0x1da264f23f26ee7fcfd739f781f1a8033f396bc8f5f66847fa6deb31d9830442'
+      startBlock: 26449267
   networkName: mumbai

--- a/schema.graphql
+++ b/schema.graphql
@@ -362,6 +362,8 @@ type FilledOrdersEvent @entity {
   makerAmountFilled: BigInt!
   "Taker amount filled"
   takerAmountFilled: BigInt!
+  "Fee paid"
+  fee: BigInt!
 }
 
 # LOP

--- a/src/OrderExecutorV2Mapping.ts
+++ b/src/OrderExecutorV2Mapping.ts
@@ -32,6 +32,7 @@ function recordEvent(event: FilledOrders): string {
   filledOrderEvent.takerAssetID =  event.params.makerAssetID
   filledOrderEvent.makerAmountFilled = event.params.takerAmountFilled
   filledOrderEvent.takerAmountFilled = event.params.makerAmountFilled
+  filledOrderEvent.fee = event.params.fee
 
   filledOrderEvent.save()
 

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -82,7 +82,7 @@ dataSources:
         - name: ERC20Detailed
           file: ./abis/ERC20Detailed.json
       eventHandlers:
-        - event: FilledOrders(address,address,address,uint256,uint256,uint256,uint256)
+        - event: FilledOrders(address,address,address,uint256,uint256,uint256,uint256,uint256)
           handler: handleFilledOrders
       file: ./src/OrderExecutorV2Mapping.ts
   - kind: ethereum/contract


### PR DESCRIPTION
In the past few days, we have updated the `OrderExecutor` and `LimitOrderProtocol` contracts. 

The objective of this PR is to keep the subgraph working with the last (and active) Clob's  contracts