### PR TITLE
Feat/market position refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,5 +23,10 @@ module.exports = {
     "prefer-template": "off",
     "eqeqeq": "off",
     "prefer-const": "off",
+    "no-restricted-syntax": "off",
+    "no-param-reassign": "off",
+    "no-underscore-dangle": "off",
+    "no-bitwise": "off",
+    "no-plusplus": "off"
   }
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -162,8 +162,10 @@ type FixedProductMarketMaker @entity {
 
   "Token which is colleralising this market"
   collateralToken: Collateral!
+  "Conditional Token Address"
+  conditionalTokenAddress: String! 
   "Conditions which this market is trading against"
-  conditions: [Condition!] @derivedFrom(field: "fixedProductMarketMakers")
+  conditions: [String!]
   "Percentage fee of trades taken by market maker. A 2% fee is represented as 2*10^16"
   fee: BigInt!
 
@@ -219,7 +221,7 @@ type FixedProductMarketMaker @entity {
 type MarketPosition @entity {
   id: ID!
   "Market on which this position is on"
-  market: FixedProductMarketMaker!
+  market: String!
   "Address which holds this position"
   user: Account!
   "The outcome which this position is supporting"
@@ -366,7 +368,7 @@ type EnrichedOrderFilled @entity {
   taker: Account!
   "Order hash"
   orderHash: Bytes!
-  "Market which transaction is interacting with"
+  "Market/CTF Token ID which the transaction is interacting with"
   market: Orderbook!
   "Buy or Sell transaction"
   side: TradeType!
@@ -380,20 +382,16 @@ type EnrichedOrderFilled @entity {
 type Orderbook @entity {
   "Token Id"
   id: ID!
-
   "Buy orders"
   buys: [EnrichedOrderFilled!]!
   "Sell orders"
   sells: [EnrichedOrderFilled!]!
-
-
   "Number of trades of any kind against this order book"
   tradesQuantity: BigInt!
   "Number of purchases of shares from this order book"
   buysQuantity: BigInt!
   "Number of sales of shares to this order book"
   sellsQuantity: BigInt!
-
   "Market volume in terms of the underlying collateral value"
   collateralVolume: BigInt!
   "Volume scaled by the number of decimals of collateralToken"
@@ -406,7 +404,6 @@ type Orderbook @entity {
   collateralSellVolume: BigInt!
   "Global volume of share sales in USDC scaled by 10^6"
   scaledCollateralSellVolume: BigDecimal!
-
   "Timestamp of last day during which someone made a trade"
   lastActiveDay: BigInt!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -220,12 +220,10 @@ type FixedProductMarketMaker @entity {
 
 type MarketPosition @entity {
   id: ID!
-  "Market on which this position is on"
+  "Market/tokenId on which this position is on"
   market: String!
   "Address which holds this position"
   user: Account!
-  "The outcome which this position is supporting"
-  outcomeIndex: BigInt!
   "Number of outcome shares that the user has ever bought"
   quantityBought: BigInt!
   "Number of outcome shares that the user has ever sold"

--- a/schema.graphql
+++ b/schema.graphql
@@ -165,7 +165,7 @@ type FixedProductMarketMaker @entity {
   "Conditional Token Address"
   conditionalTokenAddress: String! 
   "Conditions which this market is trading against"
-  conditions: [String!]
+  conditions: [String!]!
   "Percentage fee of trades taken by market maker. A 2% fee is represented as 2*10^16"
   fee: BigInt!
 

--- a/src/ExchangeMapping.ts
+++ b/src/ExchangeMapping.ts
@@ -140,7 +140,6 @@ export function handleFill(event: OrderFilled): void {
   // Update market position
   updateMarketPositionFromOrderFilled(
     maker,
-    taker,
     tokenId,
     side,
     event.params.makerAmountFilled,

--- a/src/ExchangeMapping.ts
+++ b/src/ExchangeMapping.ts
@@ -8,6 +8,7 @@ import {
 } from './types/schema';
 import { markAccountAsSeen, updateUserVolume } from './utils/account-utils';
 import { TRADE_TYPE_BUY } from './utils/constants';
+import { updateMarketPositionFromOrderFilled } from './utils/market-positions-utils';
 import {
   getOrderPrice,
   getOrderSide,
@@ -135,6 +136,17 @@ export function handleFill(event: OrderFilled): void {
   markAccountAsSeen(maker, timestamp);
 
   updateTradesQuantity(orderBook, side, orderId);
+
+  // Update market position
+  updateMarketPositionFromOrderFilled(
+    maker,
+    taker,
+    tokenId,
+    side,
+    event.params.makerAmountFilled,
+    event.params.takerAmountFilled,
+    event.params.fee,
+  );
 
   // persist order book
   orderBook.save();

--- a/src/ExchangeMapping.ts
+++ b/src/ExchangeMapping.ts
@@ -7,7 +7,7 @@ import {
   OrdersMatchedEvent,
 } from './types/schema';
 import { markAccountAsSeen, updateUserVolume } from './utils/account-utils';
-import { bigZero, TRADE_TYPE_BUY } from './utils/constants';
+import { TRADE_TYPE_BUY } from './utils/constants';
 import {
   getOrderPrice,
   getOrderSide,

--- a/src/FixedProductMarketMakerFactoryMapping.template.ts
+++ b/src/FixedProductMarketMakerFactoryMapping.template.ts
@@ -74,6 +74,7 @@ export function handleFixedProductMarketMakerCreation(
   fixedProductMarketMaker.creationTimestamp = event.block.timestamp;
   fixedProductMarketMaker.creationTransactionHash = event.transaction.hash;
   fixedProductMarketMaker.conditionalTokenAddress = conditionalTokensAddress;
+  fixedProductMarketMaker.conditions = [];
 
   getCollateralDetails(event.params.collateralToken);
   fixedProductMarketMaker.collateralToken = event.params.collateralToken.toHexString();
@@ -94,10 +95,11 @@ export function handleFixedProductMarketMakerCreation(
     }
 
     outcomeTokenCount *= condition.outcomeSlotCount;
-    condition.fixedProductMarketMakers = condition.fixedProductMarketMakers.concat(
-      [addressHexString],
-    );
+    condition.fixedProductMarketMakers =
+      condition.fixedProductMarketMakers.concat([addressHexString]);
     condition.save();
+
+    fixedProductMarketMaker.conditions = fixedProductMarketMaker.conditions.concat([conditionIdStr]);
   }
 
   fixedProductMarketMaker.outcomeSlotCount = outcomeTokenCount;

--- a/src/FixedProductMarketMakerFactoryMapping.template.ts
+++ b/src/FixedProductMarketMakerFactoryMapping.template.ts
@@ -73,6 +73,7 @@ export function handleFixedProductMarketMakerCreation(
   fixedProductMarketMaker.creator = event.params.creator;
   fixedProductMarketMaker.creationTimestamp = event.block.timestamp;
   fixedProductMarketMaker.creationTransactionHash = event.transaction.hash;
+  fixedProductMarketMaker.conditionalTokenAddress = conditionalTokensAddress;
 
   getCollateralDetails(event.params.collateralToken);
   fixedProductMarketMaker.collateralToken = event.params.collateralToken.toHexString();

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,5 +5,5 @@ export let bigOne = BigInt.fromI32(1);
 
 export const AddressZero = '0x0000000000000000000000000000000000000000';
 
-export const TRADE_TYPE_BUY = "Buy"
-export const TRADE_TYPE_SELL = "Sell"
+export const TRADE_TYPE_BUY = 'Buy';
+export const TRADE_TYPE_SELL = 'Sell';

--- a/src/utils/ctf-utils.ts
+++ b/src/utils/ctf-utils.ts
@@ -15,10 +15,12 @@ const computePositionId = (
   let collateralToken = Address.fromHexString(collateral);
   let hashPayload = new Uint8Array(52);
   hashPayload.fill(0);
+
   // 20 bytes for the token address
   for (let i = 0; i < collateralToken.length && i < 20; i++) {
     hashPayload[i] = collateralToken[i];
   }
+
   // 32 bytes for the collectionId
   for (let i = 0; i < collectionId.length && i < 32; i++) {
     hashPayload[i + 20] = collectionId[i];
@@ -136,4 +138,28 @@ export const calculatePositionIds = (
     positionIds.push(positionIdStr);
   }
   return positionIds;
+};
+
+/**
+ * Gets the CTF ERC1155 tokenId
+ * @param conditionalTokenAddress
+ * @param conditionId
+ * @param collateral
+ * @param outcomeSlotCount
+ * @param outcomeIndex
+ */
+export const getMarket = (
+  conditionalTokenAddress: string,
+  conditionId: string,
+  collateral: string,
+  outcomeSlotCount: number,
+  outcomeIndex: number,
+): string => {
+  const positionIds: string[] = calculatePositionIds(
+    conditionalTokenAddress,
+    conditionId,
+    collateral,
+    outcomeSlotCount,
+  );
+  return positionIds[outcomeIndex as i32];
 };

--- a/src/utils/ctf-utils.ts
+++ b/src/utils/ctf-utils.ts
@@ -1,0 +1,110 @@
+/* eslint-disable @typescript-eslint/ban-types */
+import { Address, log, crypto, BigInt, Bytes } from '@graphprotocol/graph-ts';
+import { ConditionalTokens } from '../types/ConditionalTokens/ConditionalTokens';
+
+const computePositionId = (collateral: string, collectionId: Bytes): Bytes => {
+  let collateralToken = Address.fromHexString(collateral);
+  let hashPayload = new Uint8Array(52);
+  hashPayload.fill(0);
+  // 20 bytes for the token address
+  for (let i = 0; i < collateralToken.length && i < 20; i++) {
+    hashPayload[i] = collateralToken[i];
+  }
+  // 32 bytes for the collectionId
+  for (let i = 0; i < collectionId.length && i < 32; i++) {
+    hashPayload[i + 20] = collectionId[i];
+  }
+  return Bytes.fromByteArray(
+    crypto.keccak256(Bytes.fromUint8Array(hashPayload)),
+  );
+};
+
+// const buildHashPayloadForInitHash = (
+//   conditionId: string,
+//   indexSet: number,
+// ): Bytes => {
+//   let hashPayload = new Uint8Array(64);
+//   hashPayload.fill(0);
+//   let conditionIdBytes = Bytes.fromHexString(conditionId);
+//   let indexSetBytes = Bytes.fromBigInt(BigInt.fromString(`${indexSet}`));
+//   for (let i = 0; i < conditionIdBytes.length && i < 32; i++) {
+//     hashPayload[i] = conditionIdBytes[i];
+//   }
+
+//   for (let i = 0; i < indexSetBytes.length && i < 32; i++) {
+//     hashPayload[i + 32] = indexSetBytes[i];
+//   }
+//   return hashPayload as Bytes;
+// };
+
+const calculateCollectionIds = (
+  conditionalTokenAddress: string,
+  conditionId: string,
+  outcomeSlotCount: number,
+): Bytes[] => {
+  const conditionalToken = ConditionalTokens.bind(
+    Address.fromString(conditionalTokenAddress),
+  );
+  const conditionIdBytes = Bytes.fromHexString(conditionId);
+  const collectionIds: Bytes[] = [];
+  const hashZero = new Uint8Array(32);
+  hashZero.fill(0);
+  const hashZeroBytes = Bytes.fromUint8Array(hashZero);
+
+  for (let i = 1; i <= outcomeSlotCount; i += 1) {
+    const collectionId = conditionalToken.getCollectionId(
+      hashZeroBytes,
+      conditionIdBytes,
+      BigInt.fromI32(i),
+    );
+
+    log.info('LOG: CTFUtils Found collectionId: {}!', [
+      collectionId.toHexString(),
+    ]);
+
+    collectionIds.push(collectionId);
+  }
+  return collectionIds;
+};
+
+/**
+ * Calculates ERC1155 token Ids
+ * @param conditionId
+ * @param collateral
+ * @param outcomeSlotCount
+ * @returns
+ */
+export const calculatePositionIds = (
+  conditionalTokenAddress: string,
+  conditionId: string,
+  collateral: string,
+  outcomeSlotCount: number,
+): string[] => {
+  log.info(
+    'LOG: CTFUtils: Calculating position ids for conditionId: {}, collateral: {}, outcomeSlotCount: {}',
+    [conditionId, collateral, outcomeSlotCount.toString()],
+  );
+
+  const collectionIds: Bytes[] = calculateCollectionIds(
+    conditionalTokenAddress,
+    conditionId,
+    outcomeSlotCount,
+  );
+
+  const positionIds: string[] = [];
+  for (let i = 0; i < collectionIds.length; i++) {
+    const collectionId = collectionIds[i];
+    const positionIdBytes = computePositionId(collateral, collectionId);
+    const positionIdHex = positionIdBytes.toHexString();
+    log.info('LOG: CTFUtils Generated PositionId Hex: {}', [positionIdHex]);
+
+    log.info('LOG: CTFUtils Generated PositionId str: {}', [
+      parseInt(positionIdHex, 16).toString(10),
+    ]);
+
+    positionIds.push(parseInt(positionIdHex, 16).toString());
+  }
+
+  log.info('LOG: CTFUtils PositionIds: {}!', [positionIds.toString()]);
+  return positionIds;
+};

--- a/src/utils/ctf-utils.ts
+++ b/src/utils/ctf-utils.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import {
   Address,
-  log,
   crypto,
   BigInt,
   Bytes,
@@ -104,11 +103,6 @@ const calculateCollectionIds = (
       conditionIdBytes,
       BigInt.fromI32(i),
     );
-
-    log.info('LOG: CTFUtils Found collectionId: {}!', [
-      collectionId.toHexString(),
-    ]);
-
     collectionIds.push(collectionId);
   }
   return collectionIds;
@@ -127,11 +121,6 @@ export const calculatePositionIds = (
   collateral: string,
   outcomeSlotCount: number,
 ): string[] => {
-  log.info(
-    'LOG: CTFUtils: Calculating position ids for conditionId: {}, collateral: {}, outcomeSlotCount: {}',
-    [conditionId, collateral, outcomeSlotCount.toString()],
-  );
-
   const collectionIds: Bytes[] = calculateCollectionIds(
     conditionalTokenAddress,
     conditionId,
@@ -143,12 +132,8 @@ export const calculatePositionIds = (
     const collectionId = collectionIds[i];
     const positionIdByteArray = computePositionId(collateral, collectionId);
     const positionIdHex = positionIdByteArray.toHexString();
-    log.info('CTFUtils Generated PositionId Hex: {}', [positionIdHex]);
     const positionIdStr = hexToDecimalString(positionIdHex);
-    log.info('CTFUtils Generated PositionId str: {}', [positionIdStr]);
     positionIds.push(positionIdStr);
   }
-
-  log.info('LOG: CTFUtils PositionIds: {}!', [positionIds.toString()]);
   return positionIds;
 };

--- a/src/utils/fpmm-utils.ts
+++ b/src/utils/fpmm-utils.ts
@@ -25,6 +25,7 @@ export function loadPoolMembership(
  */
 export function calculatePrices(outcomeTokenAmounts: BigInt[]): BigDecimal[] {
   let outcomePrices = new Array<BigDecimal>(outcomeTokenAmounts.length);
+  outcomePrices.fill(BigDecimal.zero());
 
   let totalTokensBalance = bigZero;
   let product = bigOne;

--- a/src/utils/market-positions-utils.ts
+++ b/src/utils/market-positions-utils.ts
@@ -75,14 +75,14 @@ export function updateMarketPositionFromOrderFilled(
 ): void {
   // Create/Update market position for the maker
   let position = getMarketPosition(maker, tokenId);
-  let amountNetFees = takerAmountFilled.minus(fee);
+  let takerAmountNetFees = takerAmountFilled.minus(fee);
 
   if (side == TRADE_TYPE_BUY) {
-    position.quantityBought = position.quantityBought.plus(amountNetFees);
+    position.quantityBought = position.quantityBought.plus(takerAmountNetFees);
     position.valueBought = position.valueBought.plus(makerAmountFilled);
   } else {
     position.quantitySold = position.quantitySold.plus(makerAmountFilled);
-    position.valueSold = position.valueSold.plus(amountNetFees);
+    position.valueSold = position.valueSold.plus(takerAmountNetFees);
   }
 
   updateNetPositionAndSave(position);

--- a/src/utils/market-positions-utils.ts
+++ b/src/utils/market-positions-utils.ts
@@ -69,44 +69,29 @@ function updateNetPositionAndSave(position: MarketPosition): void {
  */
 export function updateMarketPositionFromOrderFilled(
   maker: string,
-  taker: string,
   tokenId: string,
   side: string,
   makerAmountFilled: BigInt,
   takerAmountFilled: BigInt,
   fee: BigInt,
 ): void {
-  // Create/Update market position for the maker and the taker
+  // Create/Update market position for the maker
   let marketPositionMaker = getMarketPosition(maker, tokenId);
-  let marketPositionTaker = getMarketPosition(taker, tokenId);
 
   if (side == TRADE_TYPE_BUY) {
     marketPositionMaker.quantityBought =
       marketPositionMaker.quantityBought.plus(takerAmountFilled.minus(fee));
     marketPositionMaker.valueBought =
       marketPositionMaker.valueBought.plus(makerAmountFilled);
-
-    marketPositionTaker.quantitySold =
-      marketPositionTaker.quantitySold.plus(makerAmountFilled);
-    marketPositionTaker.valueSold = marketPositionTaker.valueSold.plus(
-      takerAmountFilled.minus(fee),
-    );
   } else {
     marketPositionMaker.quantityBought =
       marketPositionMaker.quantityBought.plus(makerAmountFilled);
     marketPositionMaker.valueBought = marketPositionMaker.valueBought.plus(
       takerAmountFilled.minus(fee),
     );
-
-    marketPositionTaker.quantitySold = marketPositionTaker.quantitySold.plus(
-      takerAmountFilled.minus(fee),
-    );
-    marketPositionTaker.valueSold =
-      marketPositionTaker.valueSold.plus(makerAmountFilled);
   }
 
   updateNetPositionAndSave(marketPositionMaker);
-  updateNetPositionAndSave(marketPositionTaker);
 }
 
 export function updateMarketPositionFromTrade(event: ethereum.Event): void {

--- a/src/utils/market-positions-utils.ts
+++ b/src/utils/market-positions-utils.ts
@@ -179,7 +179,7 @@ export function updateMarketPositionsFromSplit(
   const collateralToken = marketMaker.collateralToken.toString();
   const outcomeSlotCount = marketMaker.outcomeSlotCount as number;
 
-  if (conditions == null) {
+  if (conditions == null || conditions.length == 0) {
     log.error('LOG: Could not find conditions on the FPMM: {}', [
       marketMakerAddress,
     ]);
@@ -193,17 +193,14 @@ export function updateMarketPositionsFromSplit(
     outcomeIndex < outcomeTokenPrices.length;
     outcomeIndex += 1
   ) {
-    let market: string;
-    for (let i = 0; i < conditions.length; i++) {
-      const condition = conditions[i];
-      market = getMarket(
-        conditionalTokenAddress,
-        condition,
-        collateralToken,
-        outcomeSlotCount,
-        outcomeIndex,
-      );
-    }
+    let condition = conditions[0];
+    const market = getMarket(
+      conditionalTokenAddress,
+      condition,
+      collateralToken,
+      outcomeSlotCount,
+      outcomeIndex,
+    );
     let position = getMarketPosition(userAddress, market);
     // Event emits the amount of collateral to be split as `amount`
     position.quantityBought = position.quantityBought.plus(event.params.amount);
@@ -240,7 +237,7 @@ export function updateMarketPositionsFromMerge(
   const collateralToken = marketMaker.collateralToken.toString();
   const outcomeSlotCount = marketMaker.outcomeSlotCount as number;
 
-  if (conditions == null) {
+  if (conditions == null || conditions.length == 0) {
     log.error('LOG: Could not find conditions on the FPMM: {}', [
       marketMakerAddress,
     ]);
@@ -254,17 +251,14 @@ export function updateMarketPositionsFromMerge(
     outcomeIndex < outcomeTokenPrices.length;
     outcomeIndex += 1
   ) {
-    let market: string;
-    for (let i = 0; i < conditions.length; i++) {
-      const condition = conditions[i];
-      market = getMarket(
-        conditionalTokenAddress,
-        condition,
-        collateralToken,
-        outcomeSlotCount,
-        outcomeIndex,
-      );
-    }
+    let condition = conditions[0];
+    const market = getMarket(
+      conditionalTokenAddress,
+      condition,
+      collateralToken,
+      outcomeSlotCount,
+      outcomeIndex,
+    );
 
     let position = getMarketPosition(userAddress, market);
     // Event emits the amount of outcome tokens to be merged as `amount`
@@ -304,7 +298,7 @@ export function updateMarketPositionsFromRedemption(
   const collateralToken = marketMaker.collateralToken.toString();
   const outcomeSlotCount = marketMaker.outcomeSlotCount as number;
 
-  if (conditions == null) {
+  if (conditions == null || conditions.length == 0) {
     log.error('LOG: Could not find conditions on the FPMM: {}', [
       marketMakerAddress,
     ]);
@@ -326,16 +320,13 @@ export function updateMarketPositionsFromRedemption(
     while (1 << outcomeIndex < indexSets[i].toI32()) {
       outcomeIndex += 1;
     }
-    let market: string;
-    for (let k = 0; k < conditions.length; k++) {
-      market = getMarket(
-        conditionalTokenAddress,
-        conditions[k],
-        collateralToken,
-        outcomeSlotCount,
-        outcomeIndex,
-      );
-    }
+    const market = getMarket(
+      conditionalTokenAddress,
+      conditions[0],
+      collateralToken,
+      outcomeSlotCount,
+      outcomeIndex,
+    );
 
     let position = getMarketPosition(userAddress, market);
 
@@ -374,7 +365,7 @@ export function updateMarketPositionFromLiquidityAdded(
   const collateralToken = fpmm.collateralToken.toString();
   const outcomeSlotCount = fpmm.outcomeSlotCount as number;
 
-  if (conditions == null) {
+  if (conditions == null || conditions.length == 0) {
     log.error('LOG: Could not find conditions on the FPMM: {}', [fpmmAddress]);
     throw new Error(
       `ERR: Could not find conditions on the FPMM: ${fpmmAddress}`,
@@ -392,17 +383,14 @@ export function updateMarketPositionFromLiquidityAdded(
     // Subtract this from the amount of collateral added to get the amount refunded to funder
     let refundedAmount: BigInt = addedFunds.minus(amountsAdded[outcomeIndex]);
     if (refundedAmount.gt(bigZero)) {
-      let market: string;
-      for (let i = 0; i < conditions.length; i++) {
-        const condition = conditions[i];
-        market = getMarket(
-          conditionalTokenAddress,
-          condition,
-          collateralToken,
-          outcomeSlotCount,
-          outcomeIndex,
-        );
-      }
+      const condition = conditions[0];
+      const market = getMarket(
+        conditionalTokenAddress,
+        condition,
+        collateralToken,
+        outcomeSlotCount,
+        outcomeIndex,
+      );
 
       // Only update positions which have changed
       let position = getMarketPosition(funder, market);
@@ -436,7 +424,7 @@ export function updateMarketPositionFromLiquidityRemoved(
   const collateralToken = fpmm.collateralToken.toString();
   const outcomeSlotCount = fpmm.outcomeSlotCount as number;
 
-  if (conditions == null) {
+  if (conditions == null || conditions.length == 0) {
     log.error('LOG: Could not find conditions on the FPMM: {}', [fpmmAddress]);
     throw new Error(
       `ERR: Could not find conditions on the FPMM: ${fpmmAddress}`,
@@ -450,16 +438,14 @@ export function updateMarketPositionFromLiquidityRemoved(
     outcomeIndex < amountsRemoved.length;
     outcomeIndex += 1
   ) {
-    let market: string;
-    for (let i = 0; i < conditions.length; i++) {
-      market = getMarket(
-        conditionalTokenAddress,
-        conditions[i],
-        collateralToken,
-        outcomeSlotCount,
-        outcomeIndex,
-      );
-    }
+    let condition = conditions[0];
+    const market: string = getMarket(
+      conditionalTokenAddress,
+      condition,
+      collateralToken,
+      outcomeSlotCount,
+      outcomeIndex,
+    );
 
     let position = getMarketPosition(funder, market);
 

--- a/src/utils/market-positions-utils.ts
+++ b/src/utils/market-positions-utils.ts
@@ -63,7 +63,7 @@ function updateNetPositionAndSave(position: MarketPosition): void {
 }
 
 /**
- * Update market position for both sides of the Order
+ * Update market position for the maker
  */
 export function updateMarketPositionFromOrderFilled(
   maker: string,

--- a/src/utils/market-positions-utils.ts
+++ b/src/utils/market-positions-utils.ts
@@ -333,7 +333,7 @@ export function updateMarketPositionsFromRedemption(
     for (let k = 0; k < conditions.length; k++) {
       market = getMarket(
         conditionalTokenAddress,
-        conditions[i],
+        conditions[k],
         collateralToken,
         outcomeSlotCount,
         outcomeIndex,

--- a/src/utils/market-positions-utils.ts
+++ b/src/utils/market-positions-utils.ts
@@ -108,7 +108,7 @@ export function updateMarketPositionFromTrade(event: ethereum.Event): void {
   const collateralToken = fpmm.collateralToken.toString();
   const outcomeSlotCount = fpmm.outcomeSlotCount as number;
 
-  if (conditions == null) {
+  if (conditions == null || conditions.length == 0) {
     log.error('LOG: Could not find conditions on the FPMM: {}', [
       transaction.market,
     ]);
@@ -119,17 +119,14 @@ export function updateMarketPositionFromTrade(event: ethereum.Event): void {
 
   // Calculate the market/tokenId from the conditionId and the outcome index
   // Note: this assumes a single conditionId and a zero parentCollectionId
-  let market: string;
-  for (let i = 0; i < conditions.length; i++) {
-    const condition = conditions[i];
-    market = getMarket(
-      conditionalTokenAddress,
-      condition,
-      collateralToken,
-      outcomeSlotCount,
-      transaction.outcomeIndex.toI32(),
-    );
-  }
+  let condition = conditions[0];
+  const market = getMarket(
+    conditionalTokenAddress,
+    condition,
+    collateralToken,
+    outcomeSlotCount,
+    transaction.outcomeIndex.toI32(),
+  );
 
   let position = getMarketPosition(transaction.user, market);
 

--- a/src/utils/market-positions-utils.ts
+++ b/src/utils/market-positions-utils.ts
@@ -28,7 +28,6 @@ export function getMarketPosition(
   outcomeIndex: BigInt,
 ): MarketPosition {
   let positionId = user + market; // user + market tokenID
-  log.info('LOG: getMarketPosition: PositionId: {}', [positionId]);
   let position = MarketPosition.load(positionId);
   if (position == null) {
     position = new MarketPosition(positionId);
@@ -66,10 +65,6 @@ function updateNetPositionAndSave(position: MarketPosition): void {
 }
 
 export function updateMarketPositionFromTrade(event: ethereum.Event): void {
-  log.info('LOG: MarketPositionsUtils Txn hash: {}', [
-    event.transaction.hash.toHexString(),
-  ]);
-
   let transaction = Transaction.load(event.transaction.hash.toHexString());
   if (transaction == null) {
     log.error('Could not find a transaction with hash: {}', [
@@ -192,8 +187,6 @@ export function updateMarketPositionsFromSplit(
         outcomeIndex,
       );
     }
-    log.info('LOG: FromSplit calculated Market: {}', [market]);
-
     let position = getMarketPosition(
       userAddress,
       market,
@@ -259,7 +252,6 @@ export function updateMarketPositionsFromMerge(
         outcomeIndex,
       );
     }
-    log.info('LOG: FromMerge calculated Market: {}', [market]);
 
     let position = getMarketPosition(
       userAddress,
@@ -335,7 +327,6 @@ export function updateMarketPositionsFromRedemption(
         outcomeIndex,
       );
     }
-    log.info('LOG: FromRedemption calculated Market: {}', [market]);
 
     let position = getMarketPosition(
       userAddress,
@@ -407,7 +398,6 @@ export function updateMarketPositionFromLiquidityAdded(
           outcomeIndex,
         );
       }
-      log.info('LOG: LiquidityAdded calculated Market: {}', [market]);
 
       // Only update positions which have changed
       let position = getMarketPosition(
@@ -469,7 +459,6 @@ export function updateMarketPositionFromLiquidityRemoved(
         outcomeIndex,
       );
     }
-    log.info('LOG: LiquidityRemoved calculated Market: {}', [market]);
 
     let position = getMarketPosition(
       funder,

--- a/src/utils/order-book-utils.ts
+++ b/src/utils/order-book-utils.ts
@@ -125,7 +125,7 @@ export function updateGlobalVolume(
 }
 
 export function getOrderSide(makerAssetId: BigInt): string {
-  return makerAssetId.equals(BigInt.zero()) ? TRADE_TYPE_BUY : TRADE_TYPE_SELL;
+  return makerAssetId.equals(bigZero) ? TRADE_TYPE_BUY : TRADE_TYPE_SELL;
 }
 
 export function getOrderSize(

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -79,8 +79,6 @@ dataSources:
       abis:
         - name: Exchange
           file: ./abis/Exchange.json
-        - name: ERC20Detailed
-          file: ./abis/ERC20Detailed.json
       eventHandlers:
         - event: OrderFilled(indexed bytes32,indexed address,indexed address,uint256,uint256,uint256,uint256,uint256)
           handler: handleFill
@@ -108,6 +106,8 @@ templates:
       abis:
         - name: FixedProductMarketMaker
           file: ./abis/FixedProductMarketMaker.json
+        - name: ConditionalTokens
+          file: ./abis/ConditionalTokens.json
         - name: ERC20Detailed
           file: ./abis/ERC20Detailed.json
       eventHandlers:
@@ -122,6 +122,20 @@ templates:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handlePoolShareTransfer
       file: ./src/FixedProductMarketMakerMapping.ts
+  - name: ConditionalTokens
+    kind: ethereum/contract
+    network: {{networkName}}
+    source:
+      abi: ConditionalTokens
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      entities: []
+      abis:
+        - name: ConditionalTokens
+          file: ./abis/ConditionalTokens.json
+      file: ./src/empty.ts
   - name: ERC20Detailed
     kind: ethereum/contract
     network: {{networkName}}


### PR DESCRIPTION
Goal of this PR is to unify MarketPosition type across FPMMs and the Orderbook.
This is done by using the ConditionalTokens ERC1155 tokenId as the primary identifier for a position.

Refactor MarketPosition:
- Add utility function to generate the tokenId from `conditionId` + `outcomeTokenCount` + `collateral`
- Remove tight coupling with FixedProductMarketMaker and replace with tokenId
- Rewrite `updateMarketPosition*` functions so that they use tokenId

Update Exchange:
- Implement `updateMarketPositionFromOrderFilled` to create/update a MarketPosition given an OrderFilled event