### PR TITLE
Add timestamp field to Wallet entity and update on USDC transfers

### DIFF
--- a/wallet-subgraph/schema.graphql
+++ b/wallet-subgraph/schema.graphql
@@ -7,8 +7,8 @@ type Wallet @entity {
   type: String!
   "USDC.e balance"
   balance: BigInt!
-  "Last updated timestamp"
-  timestamp: BigInt!
+  "Last transfer timestamp"
+  lastTransfer: BigInt!
   "Creation timestamp"
   createdAt: BigInt!
 }

--- a/wallet-subgraph/src/RelayHub.ts
+++ b/wallet-subgraph/src/RelayHub.ts
@@ -30,7 +30,7 @@ export function handleTransactionRelayed(event: TransactionRelayed): void {
     newWallet.signer = from.toHexString();
     newWallet.type = 'proxy';
     newWallet.balance = BigInt.fromI32(0);
-    newWallet.timestamp = event.block.timestamp;
+    newWallet.lastTransfer = BigInt.fromI32(0);
     newWallet.createdAt = event.block.timestamp;
     newWallet.save();
   }

--- a/wallet-subgraph/src/SafeProxyFactory.ts
+++ b/wallet-subgraph/src/SafeProxyFactory.ts
@@ -11,7 +11,7 @@ export function handleProxyCreation(event: ProxyCreation): void {
     newWallet.signer = event.params.owner.toHexString();
     newWallet.type = 'safe';
     newWallet.balance = BigInt.fromI32(0);
-    newWallet.timestamp = event.block.timestamp;
+    newWallet.lastTransfer = BigInt.fromI32(0);
     newWallet.createdAt = event.block.timestamp;
     newWallet.save();
   }

--- a/wallet-subgraph/src/USDC.ts
+++ b/wallet-subgraph/src/USDC.ts
@@ -19,7 +19,7 @@ export function handleUSDCTransfer(event: Transfer): void {
     const wallet = Wallet.load(event.params.to.toHexString());
     if (wallet != null) {
       wallet.balance = wallet.balance.plus(event.params.amount);
-      wallet.timestamp = event.block.timestamp;
+      wallet.lastTransfer = event.block.timestamp;
       wallet.save();
 
       const globalUSDCBalance = getGlobalUSDCBalance();
@@ -35,7 +35,7 @@ export function handleUSDCTransfer(event: Transfer): void {
     const wallet = Wallet.load(event.params.from.toHexString());
     if (wallet != null) {
       wallet.balance = wallet.balance.minus(event.params.amount);
-      wallet.timestamp = event.block.timestamp;
+      wallet.lastTransfer = event.block.timestamp;
       wallet.save();
 
       const globalUSDCBalance = getGlobalUSDCBalance();


### PR DESCRIPTION
R: Add Timestamp Field to Wallet Entity in Wallet Subgraph

**Summary**
This PR adds a timestamp field to the Wallet entity in the wallet subgraph and updates the mapping logic to set this field whenever a wallet’s USDC balance is updated. This enables time-based analytics on wallet activity.

**Changes**

Added a timestamp: BigInt! field to the Wallet entity in wallet-subgraph/schema.graphql.
Updated handleUSDCTransfer in wallet-subgraph/src/USDC.ts to set the timestamp field to event.block.timestamp whenever a wallet’s balance is updated (both for incoming and outgoing transfers).

I used the way the orderbook-subgraph achieves this