### PR TITLE
Add Block Timestamps to OI Subgraph Entities

### DIFF
--- a/oi-subgraph/schema.graphql
+++ b/oi-subgraph/schema.graphql
@@ -1,6 +1,7 @@
 type Condition @entity {
   "conditionId"
   id: ID!
+  createdAt: BigInt!
 }
 
 # Neg Risk Events/Markets
@@ -11,6 +12,7 @@ type NegRiskEvent @entity {
   feeBps: BigInt!
   "Question Count"
   questionCount: Int!
+  createdAt: BigInt!
 }
 
 # Market Open Interest
@@ -19,6 +21,7 @@ type MarketOpenInterest @entity {
   id: ID!
   "Open interest for the market"
   amount: BigInt!
+  updatedAt: BigInt!
 }
 
 # Global Open Interest
@@ -27,4 +30,5 @@ type GlobalOpenInterest @entity {
   id: ID!
   "Global Open Interest"
   amount: BigInt!
+  updatedAt: BigInt!
 }

--- a/oi-subgraph/src/ConditionalTokensMapping.ts
+++ b/oi-subgraph/src/ConditionalTokensMapping.ts
@@ -25,7 +25,7 @@ export function handlePositionSplit(event: PositionSplit): void {
 
   // Split increases OI
   const amount = event.params.amount;
-  updateOpenInterest(conditionId, amount);
+  updateOpenInterest(conditionId, amount, event.block.timestamp);
 }
 
 export function handlePositionsMerge(event: PositionsMerge): void {
@@ -46,7 +46,7 @@ export function handlePositionsMerge(event: PositionsMerge): void {
   // Merge reduces OI
   const amount = event.params.amount.neg();
 
-  updateOpenInterest(conditionId, amount);
+  updateOpenInterest(conditionId, amount, event.block.timestamp);
 }
 
 export function handlePayoutRedemption(event: PayoutRedemption): void {
@@ -67,7 +67,7 @@ export function handlePayoutRedemption(event: PayoutRedemption): void {
   // Redeem reduces OI
   const amount = event.params.payout.neg();
 
-  updateOpenInterest(conditionId, amount);
+  updateOpenInterest(conditionId, amount, event.block.timestamp);
 }
 
 export function handleConditionPreparation(event: ConditionPreparation): void {
@@ -79,5 +79,6 @@ export function handleConditionPreparation(event: ConditionPreparation): void {
   // new condition
   const conditionId = event.params.conditionId.toHexString();
   const condition = new Condition(conditionId);
+  condition.createdAt = event.block.timestamp;
   condition.save();
 }

--- a/oi-subgraph/src/NegRiskAdapterMapping.ts
+++ b/oi-subgraph/src/NegRiskAdapterMapping.ts
@@ -29,7 +29,7 @@ export function handlePositionSplit(event: PositionSplit): void {
 
   // Split increases OI
   const amount = event.params.amount;
-  updateOpenInterest(conditionId, amount);
+  updateOpenInterest(conditionId, amount, event.block.timestamp);
 }
 
 export function handlePositionsMerge(event: PositionsMerge): void {
@@ -42,7 +42,7 @@ export function handlePositionsMerge(event: PositionsMerge): void {
   // Merge reduces OI
   const amount = event.params.amount.neg();
 
-  updateOpenInterest(conditionId, amount);
+  updateOpenInterest(conditionId, amount, event.block.timestamp);
 }
 
 export function handlePayoutRedemption(event: PayoutRedemption): void {
@@ -56,7 +56,7 @@ export function handlePayoutRedemption(event: PayoutRedemption): void {
   // Redeem reduces OI
   const amount = event.params.payout.neg();
 
-  updateOpenInterest(conditionId, amount);
+  updateOpenInterest(conditionId, amount, event.block.timestamp);
 }
 
 export function handlePositionsConverted(event: PositionsConverted): void {
@@ -104,9 +104,9 @@ export function handlePositionsConverted(event: PositionsConverted): void {
       // Reduce OI by the fees released to the vault
       for (let i = 0; i < noCount; i++) {
         let condition = conditionIds[i];
-        updateMarketOpenInterest(condition, feeReleasedToVault.div(divisor));
+        updateMarketOpenInterest(condition, feeReleasedToVault.div(divisor), event.block.timestamp);
       }
-      updateGlobalOpenInterest(feeReleasedToVault);
+      updateGlobalOpenInterest(feeReleasedToVault, event.block.timestamp);
     }
 
     let collateralReleasedToUser = amount.times(multiplier).neg();
@@ -116,9 +116,10 @@ export function handlePositionsConverted(event: PositionsConverted): void {
       updateMarketOpenInterest(
         condition,
         collateralReleasedToUser.div(divisor),
+        event.block.timestamp,
       );
     }
-    updateGlobalOpenInterest(collateralReleasedToUser);
+    updateGlobalOpenInterest(collateralReleasedToUser, event.block.timestamp);
   }
 }
 
@@ -126,6 +127,7 @@ export function handleMarketPrepared(event: MarketPrepared): void {
   const negRiskEvent = new NegRiskEvent(event.params.marketId.toHexString());
   negRiskEvent.questionCount = 0;
   negRiskEvent.feeBps = event.params.feeBips;
+  negRiskEvent.createdAt = event.block.timestamp;
   negRiskEvent.save();
 }
 

--- a/oi-subgraph/src/oi-utils.ts
+++ b/oi-subgraph/src/oi-utils.ts
@@ -20,25 +20,28 @@ function getGlobalOpenInterest(): GlobalOpenInterest {
   return oi as GlobalOpenInterest;
 }
 
-export function updateGlobalOpenInterest(amount: BigInt): void {
+export function updateGlobalOpenInterest(amount: BigInt, updatedAt: BigInt): void {
   let globaloi = getGlobalOpenInterest();
   globaloi.amount = globaloi.amount.plus(amount);
+  globaloi.updatedAt = updatedAt;
   globaloi.save();
 }
 
 export function updateMarketOpenInterest(
   condition: string,
   amount: BigInt,
+  updatedAt: BigInt,
 ): void {
   let mktoi = getMarketOpenInterest(condition);
   mktoi.amount = mktoi.amount.plus(amount);
+  mktoi.updatedAt = updatedAt;
   mktoi.save();
 }
 
-export function updateOpenInterest(condition: string, amount: BigInt): void {
+export function updateOpenInterest(condition: string, amount: BigInt, updatedAt: BigInt): void {
   // Update OI for the market
-  updateMarketOpenInterest(condition, amount);
+  updateMarketOpenInterest(condition, amount, updatedAt);
 
   // Update Global OI
-  updateGlobalOpenInterest(amount);
+  updateGlobalOpenInterest(amount, updatedAt);
 }


### PR DESCRIPTION
**Overview**
This PR adds block timestamp tracking to key entities in the oi-subgraph to enable time-based analytics.

**Changes**
* MarketOpenInterest & GlobalOpenInterest - Added a new field updatedAt: BigInt! to both entities in the GraphQL schema.
The updatedAt field is set to the current block’s timestamp whenever these entities are created or updated in the mappings.
* Condition & NegRiskEvent - Added a new field createdAt: BigInt! to both entities in the GraphQL schema.
The createdAt field is set to the block timestamp at the moment these entities are created.