### PR TITLE
Add Community Tools section — projects built on Polymarket

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,9 @@ These subgraphs track contracts from the following repositories:
 [https://github.com/Polymarket/ctf-exchange]
 
 [https://github.com/Polymarket/neg-risk-ctf-adapter]
+
+## 🛠 Community Tools
+
+Projects built on top of Polymarket's subgraph and APIs:
+
+- [polymarket-whales](https://github.com/al1enjesus/polymarket-whales) - Real-time whale trade tracker — monitors large orders and fires terminal + Telegram alerts. Python, MIT, zero config.


### PR DESCRIPTION
Adding a **Community Tools** section to highlight developer projects built using Polymarket's APIs and subgraph.

First entry: **polymarket-whales** — a real-time whale trade tracker that polls the CLOB API for large orders and fires alerts via terminal and Telegram.

This kind of section helps developers discover the ecosystem and encourages more building.

https://github.com/al1enjesus/polymarket-whales

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new README section and external link, with no code or runtime impact.
> 
> **Overview**
> Adds a new **Community Tools** section to `README.md` to highlight ecosystem projects built on Polymarket’s subgraph/APIs, starting with a link and description for `polymarket-whales`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 429f704f3ca44ef686ba0483e641c775a2bea755. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->