### PR TITLE
Fix README typo in Docker container note

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker compose down
 sudo docker rm polymarket-subgraph-graph-node-1 && sudo docker rm polymarket-subgraph-ipfs-1 && sudo docker rm polymarket-subgraph-postgres-1 && sudo docker rm polymarket-subgraph-ganache-1
 ```
 
-The names of you docker containers may vary; check the terminal.
+The names of you Docker containers may vary; check the terminal.
 
 ## Goldsky
 


### PR DESCRIPTION
This PR fixes a small typo in the README and capitalizes Docker consistently in the local deployment section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code or runtime behavior is affected.
> 
> **Overview**
> Fixes a typo in `README.md` by capitalizing **Docker** consistently in the local deployment note about container names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de2c04461cf3223672b679fc30dbd0f9686b70ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->