### PR TITLE
docs: note archive-node requirement for MATIC_RPC_URL and expand provider list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@
 Create a `.env` file with the following variables:
 
 ```bash
-MATIC_RPC_URL=
+MATIC_RPC_URL=https://your-polygon-rpc-endpoint
 ```
 
-Here, `MATIC_RPC_URL` should be your RPC URL for the Polygon network. Common providers include Alchemy and Infura.
+`MATIC_RPC_URL` is the full RPC URL (including the `https://` scheme) for **Polygon mainnet**. It's passed straight to Graph Node via `ethereum: 'matic:${MATIC_RPC_URL}'` in `docker-compose.yml`.
+
+Use an **archive node**. Graph Node replays history from each subgraph's `startBlock` (some reach back to 2020) and makes historical `eth_call` requests while indexing — for example, reading ERC-20 `name`/`symbol`/`decimals` in the fpmm-subgraph — which full or pruned nodes can't serve. Providers offering Polygon archive access include [Alchemy](https://www.alchemy.com/), [Chainstack](https://chainstack.com/), [Infura](https://www.infura.io/), and [QuickNode](https://www.quicknode.com/).
 
 ## Running the test suite
 


### PR DESCRIPTION
The Environment Variables section says `MATIC_RPC_URL` can be any Polygon RPC, but Graph Node indexes from each subgraph's `startBlock` (some from 2020) and issues historical `eth_call`s during indexing — e.g. the ERC-20 metadata reads in `fpmm-subgraph` (`try_name`/`try_symbol`/`try_decimals`). Full/pruned nodes can't serve those, which surfaces as hard-to-diagnose indexing failures.

This PR:
- Notes that an **archive node** is needed.
- Clarifies the value is the full `https://` URL and points to where it's consumed (`ethereum: 'matic:${MATIC_RPC_URL}'` in `docker-compose.yml`).
- Rounds out the provider list (alphabetical).

Docs-only; no code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, config template, or subgraph logic changes.
> 
> **Overview**
> **README** Environment Variables section is expanded so operators set up Polygon RPC correctly for local Graph Node.
> 
> The `.env` example now shows a full `https://` URL placeholder instead of an empty value. New copy explains that **`MATIC_RPC_URL`** must be the complete Polygon mainnet endpoint and how it is wired into Graph Node (`ethereum: 'matic:${MATIC_RPC_URL}'` in `docker-compose.yml`).
> 
> The doc now states that an **archive node** is required (historical replay from early `startBlock`s and historical `eth_call`s during indexing), and lists example providers: Alchemy, Chainstack, Infura, and QuickNode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c068f78a7e23e88b589fd564b1313310770168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->